### PR TITLE
Enable non-res overlay for displacement pressure / cooling-centers overlay for temp/heat index variables

### DIFF
--- a/src/components/Layout/VariablePanel.js
+++ b/src/components/Layout/VariablePanel.js
@@ -300,8 +300,14 @@ const VariablePanel = (props) => {
 
   useEffect(() => {
     // If user selects Displacement Pressure, automatically apply the Non-residential Overlay
+    if (mapParams.variableName?.includes('temperature') || mapParams.variableName?.toLowerCase().includes('heat index')) {
+      if (!mapParams.overlays?.includes('cooling-centers')) {
+        dispatch(setMapParams({ overlays: [ ...mapParams.overlays, 'cooling-centers' ]}));
+      }
+    }
+    // If user selects one of the Heat Indicator variables, automatically apply the Cooling Centers Overlay
     if (mapParams.variableName === 'Displacement Pressure') {
-      if (!mapParams.overlays.includes('non-res')) {
+      if (!mapParams.overlays?.includes('non-res')) {
         dispatch(setMapParams({ overlays: [ ...mapParams.overlays, 'non-res' ]}));
       }
     }

--- a/src/components/Layout/VariablePanel.js
+++ b/src/components/Layout/VariablePanel.js
@@ -301,7 +301,9 @@ const VariablePanel = (props) => {
   useEffect(() => {
     // If user selects Displacement Pressure, automatically apply the Non-residential Overlay
     if (mapParams.variableName === 'Displacement Pressure') {
-      dispatch(setMapParams({ overlay: 'non-res' }));
+      if (!mapParams.overlays.includes('non-res')) {
+        dispatch(setMapParams({ overlays: [ ...mapParams.overlays, 'non-res' ]}));
+      }
     }
   }, [mapParams.variableName, dispatch]);
 


### PR DESCRIPTION
## Problem
Variable-relevant overlays should be enabled automatically when selecting the variable

For example:
* Enable `non-res` overlay when user selects "Displacement Pressure"
* Enable `cooling-centers` overlay when user selects "Air Temperature", "Surface Temperature", or "Heat Index (Maximum)"

Fixes #169 

## Approach
* fix: fixed handled for "Displacement Pressure" -> `non-res` case - this worked for `overlay`, but now that we can select multiple overlays it need a minor adjustment
* feat: automatically enable `cooling-centers` overlay when a variable is chosen that contains the terms "heat index" or "temperature" - this should cover current and future temp-related cases :+1:


We might be able to come up with a better/more generic pattern for this, since it seems to be a common request

## How to Test
1. Navigate to https://deploy-preview-176--chicago-env-explorer.netlify.app/map
    * You should see that "Heat Index (Maximum)" is selected by default
    * You should see that "Cooling Centers" overlay is automatically toggled on because this variable is chosen
2. Select "Displacement Pressure" from the Variable dropdown
    * You should see that the "Non-Residential or Industrial Areas" overlay is toggled on when this variable is selected