### PR TITLE
Cooling center colors and text descriptions

### DIFF
--- a/src/components/Layout/VariablePanel.js
+++ b/src/components/Layout/VariablePanel.js
@@ -361,14 +361,15 @@ const VariablePanel = (props) => {
               </MenuItem>
             ))}
           </Select>
-          {mapParams.overlays.map(overlay => <>
-            <br/>
-            { overlay === 'non-res' && <>+ Non-residential or Industrial Areas</> }
-            { overlay === 'cooling-centers' && <>+ Cooling Centers in the Area</> }
-            { overlay === 'redlining areas' && <>+ Historical Redlining</> }
-            { overlay === 'wards' && <>+ Area Wards</> }
-            { overlay === 'community areas' && <>+ Community Areas</> }
-          </>)}
+          <div style={{ marginBottom: '10px' }}>
+            {mapParams.overlays?.map(overlay => <div  key={'overlay-description-' + overlay}>
+              { overlay === 'non-res' && <>+ Non-residential or Industrial Areas</> }
+              { overlay === 'cooling-centers' && <>+ Cooling Centers in the Area</> }
+              { overlay === 'redlining' && <>+ Historical Redlining</> }
+              { overlay === 'wards' && <>+ Area Wards</> }
+              { overlay === 'community_areas' && <>+ Community Areas</> }
+            </div>)}
+          </div>
 
           <Link to='/builder'>Try with multiple variables</Link>
         </FormControl>

--- a/src/components/Layout/VariablePanel.js
+++ b/src/components/Layout/VariablePanel.js
@@ -23,12 +23,12 @@ const REDLINING_COLOR_SCALE = {
 };
 
 const CC_COLOR_SCALE = {
-  'Chicago Community College': [8,81,156],
-  'Community Service Center': [49,130,189],
-  'Library': [107,174,214],
-  'Park District Spray Feature': [158,202,225],
-  'Regional Senior Center': [198,219,239],
-  'Satellite Senior Center': [239,243,255]
+  'Community Service Center': [8,81,156],
+  'Regional Senior Center': [49,130,189],
+  'Satellite Senior Center': [107,174,214],
+  'Library': [158,202,225],
+  'Chicago Community College': [198,219,239],
+  'Park District Spray Feature': [239,243,255],
 };
 
 const RedliningLegend = () => (
@@ -361,6 +361,15 @@ const VariablePanel = (props) => {
               </MenuItem>
             ))}
           </Select>
+          {mapParams.overlays.map(overlay => <>
+            <br/>
+            { overlay === 'non-res' && <>+ Non-residential or Industrial Areas</> }
+            { overlay === 'cooling-centers' && <>+ Cooling Centers in the Area</> }
+            { overlay === 'redlining areas' && <>+ Historical Redlining</> }
+            { overlay === 'wards' && <>+ Area Wards</> }
+            { overlay === 'community areas' && <>+ Community Areas</> }
+          </>)}
+
           <Link to='/builder'>Try with multiple variables</Link>
         </FormControl>
         <Gutter h={20} />

--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -442,12 +442,12 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
   };
 
   const CC_COLOR_SCALE = {
-    'Chicago Community College': [8,81,156],
-    'Community Service Center': [49,130,189],
-    'Library': [107,174,214],
-    'Park District Spray Feature': [158,202,225],
-    'Regional Senior Center': [198,219,239],
-    'Satellite Senior Center': [239,243,255]
+    'Community Service Center': [8,81,156],
+    'Regional Senior Center': [49,130,189],
+    'Satellite Senior Center': [107,174,214],
+    'Library': [158,202,225],
+    'Chicago Community College': [198,219,239],
+    'Park District Spray Feature': [239,243,255],
   };
 
   const getCcColor = (site_type) => {
@@ -792,7 +792,7 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
       // elevationScale: 1,
       extruded: true,
       filled: true,
-      getElevation: 30,
+      getElevation: 20,
       getFillColor: (feature) => {
         const site_type = feature.properties['site_type'];
         return getCcColor(site_type);
@@ -806,7 +806,7 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
         // convert to RGB
         return hex ? hex.match(/[0-9a-f]{2}/g).map(x => parseInt(x, 16)) : [0, 0, 0];
       },
-      getLineWidth: 10,
+      //getLineWidth: 5,
       getPointRadius: 5,
       getText: f => f.properties.name,
       // getTextAlignmentBaseline: 'center',
@@ -831,7 +831,7 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
       // lineJointRounded: false,
       // lineMiterLimit: 4,
       // lineWidthMaxPixels: Number.MAX_SAFE_INTEGER,
-      lineWidthMinPixels: 2,
+      lineWidthMinPixels: 1,
       // lineWidthScale: 1,
       // lineWidthUnits: 'meters',
       // material: true,


### PR DESCRIPTION
## Problem
Cooling Centers need a minor color scale adjustment

It would also be nice to show display some text providing this additional context that is included in the map

## Approach
* fix: adjust Cooling Center colors, gradient order, new order as follows:
    * Community centers (darkest blue)
    * regional/satellite senior centers
    * libraries
    * community colleges
    * park spray features (lightest blue)
* fix: show a small text description beneath Variable selection that shows the additional context added by the selected overlays

![Screenshot 2024-06-28 at 3 30 54 PM](https://github.com/healthyregions/chicago-environment-explorer/assets/1413653/e84dd004-8563-4cfb-bab3-305744cf8a46)

## How to Test
1. Navigate to https://deploy-preview-177--chicago-env-explorer.netlify.app/map
    * You should see that "Heat Index (Maximum)" is chosen by default
    * You should see beneath the Variable dropdown that we are also showing Community Areas on this map as well
2. Scroll down to Data Overlays and enable "Cooling Centers"
    * NOTE: Another PR enables the Cooling Centers automatically here (see PR #176)
    * You should see that the darkest blue is now for Community Centers, and get progressively lighter for Regional/Satellite Senior Centers, Libraries, Community Colleges, and finally Park Spray Features (lightest blue) in that order
    * You should see that the border of the Cooling Center points on the map is much less prominent
3. Scroll back up to the Variable dropdown
    * You should see beneath the Variable dropdown that we are showing both Community Areas + Cooling Centers on this map