### PR TITLE
fix: fixed one case where IndexBuilder was attempting arithmetic on string values

### DIFF
--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -340,7 +340,9 @@ const SummaryMapPage = ({ selections }) => {
             const ibDefaultDirectionality = variable.ibDefaultDirectionality || 1;
 
             // Get all values, use them to determine mean and standard deviation
-            const values = storedGeojson.features.map(f => f.properties[columnName]).filter(f => f || (!variable['ibIgnoreZero'] && f === 0));
+            const values = storedGeojson.features.map(f => f.properties[columnName])
+                .filter(f => !!Number(f))
+                .filter(f => f || (!variable['ibIgnoreZero'] && f === 0));
             if (index === 0 && values.length !== storedGeojson.features.length) {
                 console.warn(`Warning: length mismatch with ${columnName}`);
             }


### PR DESCRIPTION
## Problem
There are several one-off cases where the IndexBuilder fails to render the Map at the end

## Approach
* fix: for cases where data contains string values, filter out these values to ensure that we are only operating on numerical values

## How to Test
1. Navigate to /builder
2. Build a Custom Index that uses "Hypertension Rate"
3. Click through the wizard to get to the Map at the end
    * You should see the map is rendered properly, despite the source data containing values of `"NA"` (compare with https://chichives.com)