### PR TITLE
fix: update IndexBuilder color palette

### DIFF
--- a/src/components/IndexBuilder/HelperText.js
+++ b/src/components/IndexBuilder/HelperText.js
@@ -35,10 +35,10 @@ export const IndicatorsHelperText = ({ selections }) =>
         <style>{css}</style>
         <IconBanner alt="" src={'/icons/index-builder/banner.svg'} />
         <Typography variant="h6" gutterBottom style={{ fontWeight: 200 }}>
-            Let's create your <strong>Custom Index</strong>
+            Let's create your <strong>Custom Vulnerability Index</strong>
         </Typography>
         <Typography variant="subtitle2" style={{ marginTop: '3rem', fontWeight: 200 }}>
-            Creating your custom index in 3 easy steps:
+            Creating your custom vulnerability index in 3 easy steps:
         </Typography>
         <Grid>
             <Grid item xs={8}>
@@ -84,7 +84,7 @@ const IndexBuilderStepIcon = ({ color, stepNumber, background }) => {
     }
 };
 
-export const readmeText = (colorScale) => "The process to compute this Custom Index is as follows: \r\n" +
+export const readmeText = (colorScale) => "The process to compute this Custom Vulnerability Index is as follows: \r\n" +
     "    1. Loop over all GeoJSON features and for each selected indicator, determine mean and sample standard deviation, and use mean and standard deviation to compute zScore for each value (NaN values should be filtered out)\r\n" +
     "    2. For each GeoJSON feature, apply weights as a percentage of zScore value, and accumulate sum for each feature in CUSTOM_INDEX\r\n" +
     "    3. After weighted sums are accumulated, we should now have all CUSTOM_INDEX values - use these to determine min/max and scale from 0 to 1\r\n" +
@@ -135,7 +135,7 @@ export const WeightsHelperText = ({ selections }) => {
             </Grid>
             <Accordion>
                 <AccordionSummary id="panel-header" aria-controls="panel-content">
-                    How are these weights used to calculate the Custom Index?
+                    How are these weights used to calculate the Custom Vulnerability Index?
                 </AccordionSummary>
                 <AccordionDetails dangerouslySetInnerHTML={{
                     __html: readmeText([1,2,3,4,5,6]).replaceAll('\r\n', '<br /><br />')

--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -244,7 +244,8 @@ const SummaryMapPage = ({ selections }) => {
 
     const [showPanel, setShowPanel] = useState(false);
     const mapParams = useSelector((state) => state.mapParams);
-    const colorScale = [[242,240,247],[218,218,235],[188,189,220],[158,154,200],[117,107,177],[84,39,143]];
+    //const colorScale = [[242,240,247],[218,218,235],[188,189,220],[158,154,200],[117,107,177],[84,39,143]];
+    const colorScale = [[69,117,180],[145,191,219],[224,243,248],[254,224,144],[252,141,89],[215,48,39]];
 
     // We don't need the actual image data, only takeScreenshot
     const [/* image */, takeScreenshot] = useScreenshot({

--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -13,7 +13,7 @@ import Button from "@mui/material/Button";
 import {createFileName, useScreenshot} from "use-react-screenshot";
 import {jenks, max, mean, min, quantile, sampleStandardDeviation, sum, zScore} from "simple-statistics";
 import {useDispatch, useSelector} from "react-redux";
-import {changeVariable, setPanelState} from "../../actions";
+import {changeVariable, setMapParams, setPanelState} from "../../actions";
 import {useChivesData} from "../../hooks/useChivesData";
 import {useHistory} from "react-router-dom";
 import JSZip from 'jszip';
@@ -437,6 +437,7 @@ const SummaryMapPage = ({ selections }) => {
 
     if (mapParams.variableName !== 'Custom Index') {
         dispatch(changeVariable(variablePresets['Custom Index']));
+        dispatch(setMapParams({ overlays: ['community_areas'] }))
     }
 
     const getUniqueGroupNames = () => {
@@ -504,9 +505,9 @@ const SummaryMapPage = ({ selections }) => {
                     className={showPanel ? "" : "hidden"}
                     style={{ top: '110px', left: '20px', width: '375px' }}>
                     <div style={{ padding: '0 2rem', marginTop: '2rem' }}>
-                        <Typography variant={'h6'} style={{ marginBottom: '1rem' }}>Custom Index</Typography>
+                        <Typography variant={'h6'} style={{ marginBottom: '1rem' }}>Custom Vulnerability Index</Typography>
                         <Typography variant={'body2'}>
-                            <p>The custom index you created has theme{getUniqueGroupNames().length > 1 && <>s</>}:</p>
+                            <p>The custom vulnerability index you created has theme{getUniqueGroupNames().length > 1 && <>s</>}:</p>
                             <p>
                                 {
                                     getUniqueGroupNames()
@@ -528,6 +529,7 @@ const SummaryMapPage = ({ selections }) => {
                                 </p>*/
                             }
 
+                            <p>Higher scores correspond to <i>increased</i> vulnerability. Lower scores correspond to less vulnerable areas.</p>
                         </Typography>
                     </div>
                     <div style={{ padding: '0 2rem 1rem 2rem' }}>

--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -244,7 +244,6 @@ const SummaryMapPage = ({ selections }) => {
 
     const [showPanel, setShowPanel] = useState(false);
     const mapParams = useSelector((state) => state.mapParams);
-    //const colorScale = [[242,240,247],[218,218,235],[188,189,220],[158,154,200],[117,107,177],[84,39,143]];
     const colorScale = [[69,117,180],[145,191,219],[224,243,248],[254,224,144],[252,141,89],[215,48,39]];
 
     // We don't need the actual image data, only takeScreenshot

--- a/src/components/Layout/VariablePanel.js
+++ b/src/components/Layout/VariablePanel.js
@@ -218,7 +218,7 @@ const ControlsContainer = styled.div`
     max-height: 100%;
     padding: 0 10px 25vh 10px;
   }
-  div.data-description {
+  p.data-description {
     max-width: 40ch;
     line-height: 1.3;
   }
@@ -379,11 +379,11 @@ const VariablePanel = (props) => {
             </div>)}
           </div>
 
-          <Link to='/builder'>Try with multiple variables</Link>
+          <Link to='/builder'>Create a Custom Vulnerability Index using multiple variables</Link>
         </FormControl>
         <Gutter h={20} />
         <h2>Data Description</h2>
-        <div className="data-description">
+        <p className="data-description">
           {mapParams.custom === 'aq_grid' && <>
           <code>Data from {aqLastUpdated.start?.slice(0,10)} to {aqLastUpdated.end?.slice(0,10)} </code>
           </>}
@@ -407,7 +407,7 @@ const VariablePanel = (props) => {
         </>
         }
           {dataDescriptions[mapParams.variableName]}
-        </div>
+        </p>
 
 
         <Gutter h={20} />


### PR DESCRIPTION
## Problem
The current purple color scale for the IndexBuilder is confusing - users have trouble telling whether high or low values are"worse"

Fixes #180 

## Approach
* fix: adjust color scale for the Index Builder so that it goes from blue (low vulnerability) -> yellow (neutral) -> red (high vulnerability)

![Screenshot 2024-07-24 at 1 05 05 PM](https://github.com/user-attachments/assets/2eed1212-bc8e-414a-8965-0f670979109e)

## How to Test
1. Navigate to /builder
2. Select one or more variables from which to build a Custom Index, and click Next
3. Assign weights to each selected indicator, and click Next
4. View the map visualization for your Custom Index
    * You should see that the color scale now goes from blue (less vulnerable) to yellow (mildly vulnerable) to red (more vulnerable)