### PR TITLE
fix: more granularity for histogram filtering + info icons with histogram descriptions

### DIFF
--- a/src/components/Charts/DensityChart.js
+++ b/src/components/Charts/DensityChart.js
@@ -15,14 +15,10 @@ export default function BarChartComponent({data, dataKey, color}){
     return (
       <ResponsiveContainer width="100%">
         <AreaChart
-          width={500}
-          height={400}
           data={data}
           margin={{
             top: 20,
-            right: 30,
-            left: 0,
-            bottom: 0,
+            right: 10,
           }}
         >
             <CartesianGrid horizontal={false}/>

--- a/src/components/Charts/DensityChart.js
+++ b/src/components/Charts/DensityChart.js
@@ -18,7 +18,6 @@ export default function BarChartComponent({data, dataKey, color}){
           data={data}
           margin={{
             top: 20,
-            right: 10,
           }}
         >
             <CartesianGrid horizontal={false}/>

--- a/src/components/Charts/Histogram.js
+++ b/src/components/Charts/Histogram.js
@@ -9,9 +9,14 @@ import withStyles from '@mui/styles/withStyles';
 
 import DensityChart from './DensityChart';
 import { applyFilterValues, removeFilterValues } from '../../actions';
-import { colors } from '../../config';
+import {colors, variablePresets} from '../../config';
 import PropTypes from "prop-types";
 import clsx from "clsx";
+import {IconButton} from "@mui/material";
+import {FaQuestionCircle} from "@react-icons/all-files/fa/FaQuestionCircle";
+import Popover from "@mui/material/Popover";
+import Typography from "@mui/material/Typography";
+import {FaInfoCircle} from "@react-icons/all-files/fa/FaInfoCircle";
 
 const HistogramContainer = styled.div`
   position:relative;
@@ -208,10 +213,54 @@ export default function Histogram({
     setSliderValue([range.min, range.max]);
   }
 
+  const [popoverAnchorEl, setPopoverAncherEl] = React.useState(null);
+  const isPopoverOpen = Boolean(popoverAnchorEl)
+  const popoverId = isPopoverOpen ? 'simple-popover' : undefined;
+
+  const handleInfoOpen = (evt) => {
+    setPopoverAncherEl(evt.currentTarget);
+  };
+
+  const handleInfoClose = () => {
+    setPopoverAncherEl(null);
+  };
+
+  const getVariableDescription = (column) => {
+    return Object.values(variablePresets).find((variable) => variable.Column === column)?.Description
+  }
+
+  const description = getVariableDescription(column);
+
   return (
     <HistogramContainer>
-      <h4>{name}</h4>
-      <ResetButton onClick={() => resetFilter()}>reset</ResetButton>
+      <h4>
+        {name}
+        {description && <IconButton aria-label={name + ' additional info'}
+                    onClick={handleInfoOpen}
+                    style={{ marginLeft: '0.5rem', color: 'rgb(185, 209, 159)' }}
+                    size={'small'}>
+          <FaInfoCircle />
+        </IconButton>}
+      </h4>
+
+      <Popover
+          id={popoverId}
+          style={{ maxWidth: '75vw' }}
+          open={isPopoverOpen}
+          anchorEl={popoverAnchorEl}
+          onClose={handleInfoClose}
+          anchorPosition={'left'}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
+      >
+        <Typography sx={{ p: 2 }}
+                    dangerouslySetInnerHTML={{ __html: description }}></Typography>
+      </Popover>
+
+      <ResetButton  style={{ marginTop: '1rem' }}
+                    onClick={() => resetFilter()}>reset</ResetButton>
 
       <ChartContainer>
         <DensityChart

--- a/src/components/Charts/Histogram.js
+++ b/src/components/Charts/Histogram.js
@@ -21,6 +21,7 @@ import {FaInfoCircle} from "@react-icons/all-files/fa/FaInfoCircle";
 const HistogramContainer = styled.div`
   position:relative;
   margin:1rem 0 0 0;
+  padding-right: 1rem;
   h4 {
     font-size:1rem;
     margin:0;
@@ -31,7 +32,6 @@ const HistogramContainer = styled.div`
 
 const ChartContainer = styled.div`
   display:block;
-  width:calc(100% - 1em);
   margin-top:5px;
   height:125px;
   cursor:crosshair !important;
@@ -103,10 +103,10 @@ const StyledSlider = withStyles({
     color: colors.cartoColors.gray,
     height: 0,
     padding: '0 25px 0 15px',
-    marginLeft:'0px',
-    width:'calc(100% - 42px)',
+    // marginLeft:'0px',
+    // width:'calc(100% - 42px)',
     boxSizing: 'border-box',
-    transform: 'translateY(-30px)'
+    transform: 'translateY(-28px)'
   },
   thumb: {
     height: 75,

--- a/src/components/Charts/Histogram.js
+++ b/src/components/Charts/Histogram.js
@@ -32,7 +32,7 @@ const HistogramContainer = styled.div`
 const ChartContainer = styled.div`
   display:block;
   width:calc(100% - 1em);
-  margin:20px auto 0 auto;
+  margin-top:20px;
   height:125px;
   cursor:crosshair !important;
   .recharts-cartesian-axis-tick {    
@@ -116,7 +116,6 @@ const StyledSlider = withStyles({
     borderLeft: '2px dotted #767676',
     position: 'absolute',
     marginTop: -35,
-    marginLeft: 10,
     boxShadow: '#00000044 0 2px 2px',
     borderRadius:0,
     '&:focus, &:hover, &$active': {
@@ -186,7 +185,7 @@ export default function Histogram({
 }){
 
   const dispatch = useDispatch();
-  const minDistanceBetweenThumbs = (range.max-range.min)/11;
+  const minDistanceBetweenThumbs = (range.max-range.min)/101;
   const [sliderValue, setSliderValue] = useState([range.min, range.max]);
 
   const valueChangeHandler = (e, newValues, activeThumb) => {

--- a/src/components/Charts/Histogram.js
+++ b/src/components/Charts/Histogram.js
@@ -137,7 +137,7 @@ const StyledSlider = withStyles({
       top: 0,
       right: 0,
       borderStyle: 'solid',
-      borderRadius: 0, 
+      borderRadius: 0,
     },
     '&.second-thumb::after': {
       borderWidth: '10px 0 10px 10px',
@@ -179,7 +179,7 @@ export default function Histogram({
   range,
   color
 }){
-  
+
   const dispatch = useDispatch();
   const minDistanceBetweenThumbs = (range.max-range.min)/11;
   const [sliderValue, setSliderValue] = useState([range.min, range.max]);
@@ -207,18 +207,18 @@ export default function Histogram({
     dispatch(removeFilterValues(column));
     setSliderValue([range.min, range.max]);
   }
-  
+
   return (
     <HistogramContainer>
       <h4>{name}</h4>
       <ResetButton onClick={() => resetFilter()}>reset</ResetButton>
-      
+
       <ChartContainer>
-        <DensityChart 
+        <DensityChart
           data={density}
-          // density={density} 
-          xAxis={'max'} 
-          dataKey={'density'} 
+          // density={density}
+          xAxis={'max'}
+          dataKey={'density'}
           color={color}
         />
       </ChartContainer>
@@ -232,7 +232,7 @@ export default function Histogram({
         defaultValue={[range.min, range.max]}
         min={range.min}
         max={range.max}
-        step={(range.max-range.min)/10}
+        step={(range.max-range.min)/100}
         disableSwap
       />
 

--- a/src/components/Charts/Histogram.js
+++ b/src/components/Charts/Histogram.js
@@ -32,7 +32,7 @@ const HistogramContainer = styled.div`
 const ChartContainer = styled.div`
   display:block;
   width:calc(100% - 1em);
-  margin-top:20px;
+  margin-top:5px;
   height:125px;
   cursor:crosshair !important;
   .recharts-cartesian-axis-tick {    

--- a/src/components/Charts/Histogram.js
+++ b/src/components/Charts/Histogram.js
@@ -56,17 +56,20 @@ const ChartContainer = styled.div`
 //   }
 // `
 
+const InfoBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size:0.65rem;
+`
+
 const ResetButton = styled.button`
   background:none;
   border:none;
   border-bottom:1px solid ${colors.darkgray};
-  position:absolute;
-  top:1rem;
-  right:1rem;
-  text-transform:uppercase;
   font-size:0.5rem;
-  padding:0.25rem;
   font-weight:bold;
+  padding:0.25rem;
   cursor:pointer;
   box-shadow: 0px 0px 0px ${colors.gray}00;
   transition:250ms all;
@@ -103,10 +106,10 @@ const StyledSlider = withStyles({
     marginLeft:'0px',
     width:'calc(100% - 42px)',
     boxSizing: 'border-box',
-    transform: 'translateY(-55px)'
+    transform: 'translateY(-30px)'
   },
   thumb: {
-    height: 95,
+    height: 75,
     width: 2,
     pointerEvents: "auto!important",
     // borderLeft: '6px solid rgba(0,0,0,0)',
@@ -258,10 +261,12 @@ export default function Histogram({
                     dangerouslySetInnerHTML={{ __html: description }}></Typography>
       </Popover>
 
-      <ResetButton  style={{ marginTop: '1rem' }}
-                    onClick={() => resetFilter()}>reset</ResetButton>
 
       <ChartContainer>
+      <InfoBar>
+        <span><strong>MIN:</strong> {Math.round(sliderValue[0]*100)/100}&nbsp;&nbsp;<strong>MAX:</strong> {Math.round(sliderValue[1]*100)/100}</span>
+        <ResetButton onClick={() => resetFilter()}>RESET</ResetButton>
+      </InfoBar>
         <DensityChart
           data={density}
           // density={density}

--- a/src/components/Map/DataPanel.js
+++ b/src/components/Map/DataPanel.js
@@ -18,8 +18,12 @@ import Histogram from '../Charts/Histogram';
 import { Gutter } from '../Layout/Gutter';
 // import NeighborhoodCounts from './NeighborhoodCounts';
 import { setPanelState } from '../../actions';
-import { colors } from '../../config';
+import {colors, variablePresets} from '../../config';
 import { report } from '../../config/svg';
+import {IconButton} from "@mui/material";
+import {FaQuestionCircle} from "@react-icons/all-files/fa/FaQuestionCircle";
+import Popover from "@mui/material/Popover";
+import Typography from "@mui/material/Typography";
 
 //// Styled components CSS
 // Main container for entire panel
@@ -472,16 +476,17 @@ const DataPanel = () => {
                 <Gutter height="1em" />
                 <h3 className="sectionHeader">Environmental</h3>
                 {
-                  EnvironmentalColumnsToChart.map(({name, column, color}, i) =>
-                    <Histogram
-                      name={name}
-                      column={column}
-                      histCounts={selectionData.histCounts[column]}
-                      density={selectionData.densities[column]}
-                      range={ranges[column]}
-                      color={color}
-                      key={`distribution-${i}`}
-                    />
+                  EnvironmentalColumnsToChart.map(({name, column, color, description}, i) => <>
+                      <Histogram
+                        name={name}
+                        column={column}
+                        histCounts={selectionData.histCounts[column]}
+                        density={selectionData.densities[column]}
+                        range={ranges[column]}
+                        color={color}
+                        key={`distribution-${i}`}
+                      />
+                    </>
                   )
                 }
                 <Gutter height="1em" />

--- a/src/components/Map/DataPanel.js
+++ b/src/components/Map/DataPanel.js
@@ -208,12 +208,12 @@ const ReportWrapper = styled.div`
     background-position: center center;
     background-repeat: no-repeat, no-repeat;
     background-size: 50%, 100%; 
-  }
+  
 `
 
 // Inner container for report content
 const ReportContainer = styled.div`
-    padding:5px 0 200px 30px;
+    padding:10px 15px 200px 15px;
     box-sizing:border-box;
     overflow-x:visible;
     // Multi-column layout (NYI)
@@ -245,12 +245,6 @@ const ReportContainer = styled.div`
       margin:0;
       padding:0 !important;
     }
-
-    div.numberChartContainer {
-      width:100%;
-      display:flex;
-      align-items: center;
-    }
     div.numberContainer {
       display:flex;
     }
@@ -261,13 +255,10 @@ const ReportContainer = styled.div`
 `
 
 // Subsection of report
-const ReportSection = styled.span`
-    padding-right:20px;
-    box-sizing:border-box;
-    // width:100%;
-    // display:inline-block;
-    padding: 0;
-    margin: 0;
+const ReportSection = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 `
 
 // // Toggle styling for condensed and expanded drop down
@@ -451,23 +442,18 @@ const DataPanel = () => {
     {selectionData.success &&
         <ReportWrapper>
             <ReportContainer>
-                <h1>Current View</h1>
                 <ReportSection>
+                    <h1>Current View</h1>
                     <p>Tree Canopy Coverage</p>
-                    <div className="numberChartContainer">
-                        <div className="h3">{selectionData.treeCoverage.toFixed(1)}%</div>
-                    </div>
+                    <h3>{selectionData.treeCoverage.toFixed(1)}%</h3>
                     <p>Heat Island Percentile</p>
-                    <div className="numberChartContainer">
-                        <div className='h3'>{selectionData.heatIsland.toFixed(1)}</div>
-                    </div>
-                    <p>Averaged over {selectionData.sums.count} census tracts</p>
-                    {/* <NeighborhoodCounts
+                    <h3>{selectionData.heatIsland.toFixed(1)}</h3>
+                    {/* <p>Averaged over {selectionData.sums.count} census tracts</p>
+                    <NeighborhoodCounts
                       counts={selectionData.communityCounts}
                       activeCommunities={filterValues.community}
                     /> */}
                 </ReportSection>
-                <Gutter height="1em" />
                 <h2>Filters</h2>
                 <br/>
                 <p style={{padding:0}}>


### PR DESCRIPTION
## Problem
When filtering with the histograms in the DataPanel, there are only 10 possible values/locations to select from

Fixes #133 

Fixes #170 

## Approach
* fix: increase the number of selectable values from `10` to `100` - this should allow user to choose more specifically where the bounds of their filter should be
* feat: add info popovers to each histogram - those that define a `Description` will have it displayed here (hidden otherwise)

## How to Test
TBD