### PR TITLE
fix: some href links on homepage have invalid syntax

### DIFF
--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -391,9 +391,9 @@ export default function Home() {
                     map using different data breakpoints. Click on the map for more data!<br /><br />
                     The map was co-designed with multiple community partners and organizations.
                   </span>
-                  <span> <a href="{process.env.PUBLIC_URL + /data}">Data</a> comes from collaborators across the city and beyond. Read more about the </span>
-                  <a href="{process.env.PUBLIC_URL + /about}">project</a><span> and </span>
-                  <a href="{process.env.PUBLIC_URL + /about/team}">team</a>. </p>
+                  <span> <a href={`${process.env.PUBLIC_URL}/data`}>Data</a> comes from collaborators across the city and beyond. Read more about the </span>
+                  <a href={`${process.env.PUBLIC_URL}/about`}>project</a><span> and </span>
+                  <a href={`${process.env.PUBLIC_URL}/team`}>team</a>. </p>
             </Grid>
 
             <Grid item xs={12} sm={12} md={6}>
@@ -513,11 +513,11 @@ export default function Home() {
       <p className={'font-lg'}>From 2022-2024, DePaul University partnered with the University of Illinois at Urbana-Champaign
         and multiple community organizations to expand ChiVes and make it more accessible.
         <br /><br />
-        Thanks to funding by NASA, the latest release of ChiVes includes expanded learning resources, new data, and improved user experience. 
+        Thanks to funding by NASA, the latest release of ChiVes includes expanded learning resources, new data, and improved user experience.
          Read the final Community Report for an overview (in <a href="https://drive.google.com/file/d/1pe3grtQEo8m8zbt4eUOzxaziCilPGNWH/view?usp=sharing">
-         English</a> and <a href="https://drive.google.com/file/d/1KjXDWpj46NBOi1lq1puc8s3XFDf3Ucrv/view?usp=sharing">en Español</a>). 
+         English</a> and <a href="https://drive.google.com/file/d/1KjXDWpj46NBOi1lq1puc8s3XFDf3Ucrv/view?usp=sharing">en Español</a>).
         <br /><br />
-        <a href="learn">Learn Resources</a> include new tutorials and a video tour.
+        <a href="/learn">Learn Resources</a> include new tutorials and a video tour.
         </p>
     </Grid>
 


### PR DESCRIPTION
## Problem
Several links on the Home page have invalid syntax

![image](https://github.com/user-attachments/assets/7452b2bb-6354-4c4e-8d3f-5695bd4b6ae0)

## Approach
* fix: adjust links to use proper syntax

## How to Test
1. Navigate to the Home page
2. Scroll down to the section that has 3 links: Data, About, and Team
3. Click each of these links to ensure that the problem has been resolved
    * Compare with https://chichives.com